### PR TITLE
BNC#878073 bug fix.

### DIFF
--- a/package/yast2-cluster.changes
+++ b/package/yast2-cluster.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed May 21 06:49:25 UTC 2014 - nwang@suse.com
+
+- BNC#878073. Stating to run "journalctl -xn" manually for log.
+  Update version to 3.1.2 to trigger ibs/obs release.
+
+-------------------------------------------------------------------
 Wed Apr 23 07:41:49 UTC 2014 - nwang@suse.com
 
 - BNC#874710, Only active or passive of rrp_mode is valid 

--- a/package/yast2-cluster.spec
+++ b/package/yast2-cluster.spec
@@ -18,7 +18,7 @@
 
 Name:           yast2-cluster
 %define _fwdefdir /etc/sysconfig/SuSEfirewall2.d/services
-Version:        3.1.1
+Version:        3.1.2
 Release:        0
 License:	GPL-2.0
 Group:		System/YaST

--- a/src/include/cluster/dialogs.rb
+++ b/src/include/cluster/dialogs.rb
@@ -901,13 +901,16 @@ module Yast
         if ret == "start_now"
           Cluster.save_csync2_conf
           Cluster.SaveClusterConfig
-          Report.Error(Service.Error) if !Service.Start("pacemaker")
+          # BNC#872651 , add more info about error message
+          errormsg = "See 'journalctl -xn' for details"
+          Report.Error(Service.Error + errormsg) if !Service.Start("pacemaker")
           next
         end
 
         if ret == "stop_now"
+          errormsg = "See 'journalctl -xn' for details"
           # BNC#874563,stop pacemaker could stop corosync since BNC#872651 is fixed
-          Report.Error(Service.Error) if !Service.Stop("pacemaker")
+          Report.Error(Service.Error + errormsg) if !Service.Stop("pacemaker")
           next
         end
 


### PR DESCRIPTION
Stating to run 'journalctl -xn' manually for log. Update version to 3.1.2
Ugly fix for showing  'journalctl -xn'. cause service.error may not update the details reason of error.
