### PR TITLE
bsc#1083439, Fix the traceback when starting without corosync.conf

### DIFF
--- a/package/yast2-cluster.changes
+++ b/package/yast2-cluster.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Mar  2 08:01:20 UTC 2018 - nwang@suse.com
+
+- bsc#1083439, fix traceback when starting without corosync.conf
+- Version 4.0.5
+
+-------------------------------------------------------------------
 Tue Jan 23 09:04:02 UTC 2018 - knut.anderssen@suse.com
 
 - SuSEFirewall2 replaced by firewalld(fate#323460)

--- a/package/yast2-cluster.spec
+++ b/package/yast2-cluster.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package yast2-cluster
 #
-# Copyright (c) 2014 SUSE LINUX Products GmbH, Nuernberg, Germany.
+# Copyright (c) 2018 SUSE Products GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -18,7 +18,7 @@
 
 Name:           yast2-cluster
 %define _fwdefdir %{_libexecdir}/firewalld/services
-Version:        4.0.4
+Version:        4.0.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/servers_non_y2/ag_openais
+++ b/src/servers_non_y2/ag_openais
@@ -188,11 +188,12 @@ qb_option_table = { "ipc_type":{"doc":"This specifies type of IPC to use",
 		  }
 
 # Using [] instead of {} is because some sections like nodelist have many nodes
-totem_options = {}
-logging_options = {}
+# Default value to avoid traceback in doRead when without corosync.conf
+totem_options = {"interface":[]}
+logging_options = {"logger_subsys":[]}
 quorum_qdevice_options={}
-quorum_options={}
-nodelist_options={}
+quorum_options={"device":quorum_qdevice_options}
+nodelist_options={"node":[]}
 qb_options={}
 
 def strip_comments_and_pending_space(line):
@@ -716,7 +717,6 @@ class OpenAISConf_Parser(object):
 		pass
 
 	def doWrite(self, path, args):
-		global quorum_options
 		global quorum_qdevice_options
 
 		if path[0] == "":
@@ -727,8 +727,11 @@ class OpenAISConf_Parser(object):
 				quorum_options[path[1]] = args
 				return "true"
 			elif len(path) == 2 and path[1] == "device" and args == "":
-				del(quorum_options["device"])
-				quorum_qdevice_options = {}
+				# May no "device" in quorum_options,
+				# cause reset in file_parser
+				if is_quorum_qdevice_configured():
+					del(quorum_options["device"])
+					quorum_qdevice_options = {}
 				return "true"
 			elif len(path) == 3 and path[1] == "device" and \
 				path[2] in quorum_qdevice_option_table.keys():


### PR DESCRIPTION
If yast cluster started without an exist corosync.conf, the hash list is empty, which led a traceback while reading.