### PR TITLE
bsc#1132640, warn rrp_mode active is deprecated. Version 4.1.2

### DIFF
--- a/package/yast2-cluster.changes
+++ b/package/yast2-cluster.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Apr 17 05:19:04 UTC 2019 - nick wang <nwang@suse.com>
+
+- Warn rrp_mode active is deprecated (bsc#1132640)
+- 4.1.2
+
+-------------------------------------------------------------------
 Sun Nov 25 17:38:07 UTC 2018 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Provide icon with module (boo#1109310)

--- a/package/yast2-cluster.spec
+++ b/package/yast2-cluster.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-cluster
-Version:        4.1.1
+Version:        4.1.2
 Release:        0
 
 BuildArch:      noarch

--- a/src/include/cluster/dialogs.rb
+++ b/src/include/cluster/dialogs.rb
@@ -273,6 +273,8 @@ module Yast
           UI.ChangeWidget(Id(:rrpmode), :Value, "passive")
           UI.SetFocus(Id(:rrpmode))
           return false
+        elsif UI.QueryWidget(Id(:rrpmode), :Value) == "active"
+          Popup.Message(_("rrp mode active is deprecated, better use passive."))
         end
       end
 


### PR DESCRIPTION
Pop up a warning message when using active rrp_mode, not raise any failure. This is cherry-pick from SLE15SP1 branch