### PR TITLE
bsc#1144200, stop corosync instead of pacemaker

### DIFF
--- a/package/yast2-cluster.changes
+++ b/package/yast2-cluster.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Aug  5 06:23:32 UTC 2019 - nick wang <nwang@suse.com>
+
+- bsc#1144200, stop corosync instead of pacemaker.
+  The patch in corosync(bsc#872651) is dropped in bsc#1144200,
+  change back to stop corosync.
+- 4.2.1
+
+-------------------------------------------------------------------
 Fri May 31 12:27:33 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Add metainfo (fate#319035)

--- a/package/yast2-cluster.spec
+++ b/package/yast2-cluster.spec
@@ -18,7 +18,7 @@
 %define _fwdefdir %{_libexecdir}/firewalld/services
 
 Name:           yast2-cluster
-Version:        4.2.0
+Version:        4.2.1
 Release:        0
 Summary:        Configuration of cluster
 License:        GPL-2.0-only

--- a/src/include/cluster/dialogs.rb
+++ b/src/include/cluster/dialogs.rb
@@ -1138,7 +1138,8 @@ module Yast
 
         if ret == "stop_now"
           # BNC#874563,stop pacemaker could stop corosync since BNC#872651 is fixed
-          Report.Error(Service.Error + errormsg) if !Service.Stop("pacemaker")
+          # In bnc#1144200, the patch is dropped in corosync, so stop pacemaker not working
+          Report.Error(Service.Error + errormsg) if !Service.Stop("corosync")
           next
         end
 


### PR DESCRIPTION
bsc#1144200, stop corosync instead of pacemaker.

The patch(bnc#872651-stop-cluster.patch of Package corosync) in corosync(bsc#872651) is dropped in bsc#1144200 due to upstream policy, change back to stop corosync.