### PR TITLE
bsc#1149089 qdevice service should also be install

### DIFF
--- a/src/modules/Cluster.rb
+++ b/src/modules/Cluster.rb
@@ -490,7 +490,8 @@ module Yast
         "csync2",
         "conntrack-tools",
         "hawk2",
-        "crmsh"
+        "crmsh",
+        "corosync-qdevice"
       ]
       ret = PackageSystem.CheckAndInstallPackagesInteractive(required_pack_list)
       if ret == false


### PR DESCRIPTION
The qdevice service is configurable, but the service
not installed automatically (like csync2, etc).

Signed-off-by: yuan ren <yren@suse.com>