### PR TITLE
bsc#1151687, update the open ports to support pacemaker-remote, booth and corosync-qnetd

### DIFF
--- a/package/cluster.fwd
+++ b/package/cluster.fwd
@@ -6,10 +6,14 @@
 # 5560 for mgmtd
 # 7630 for hawk or hawk2
 # 21064 for dlm
-TCP="30865 5560 7630 21064"
+# 3121 for pacemaker-remote
+# tcp 2224 5403, udp 5404 5405 for corosync-qnetd
+# tcp 9929, udp 9929 for booth
+
+TCP="30865 5560 7630 21064 3121 2224 5403 9929"
 
 # space separated list of allowed UDP ports
-UDP=""
+UDP="5404 5405 9929"
 
 # space separated list of allowed RPC services
 RPC=""

--- a/package/yast2-cluster.changes
+++ b/package/yast2-cluster.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep 25 06:08:12 UTC 2019 - nick wang <nwang@suse.com>
+
+- bsc#1151687, update the open ports to support pacemaker-remote,
+  booth, corosync-qnetd.
+- Version 3.4.1
+
+-------------------------------------------------------------------
 Mon Jan 14 07:41:14 UTC 2019 - nwang@suse.com
 
 - bsc#1120815, support use hostname in ring address.

--- a/package/yast2-cluster.spec
+++ b/package/yast2-cluster.spec
@@ -18,7 +18,7 @@
 
 Name:           yast2-cluster
 %define _fwdefdir /etc/sysconfig/SuSEfirewall2.d/services
-Version:        3.4.0
+Version:        3.4.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
bsc#1151687, update the open ports to support pacemaker-remote, booth and corosync-qnetd

The package version of SLE12SP3 is in correct, which will cause trouble when upgrading to SP4 and SP5... So also bump up version in SLE12SP4/SP5. In SLE15, everything back to normal.