### PR TITLE
bsc#1151687, update the open ports to support pacemaker-remote, booth and corosync-qnetd

### DIFF
--- a/package/cluster.fwd
+++ b/package/cluster.fwd
@@ -6,10 +6,14 @@
 # 5560 for mgmtd
 # 7630 for hawk or hawk2
 # 21064 for dlm
-TCP="30865 5560 7630 21064"
+# 3121 for pacemaker-remote
+# tcp 2224 5403, udp 5404 5405 for corosync-qnetd
+# tcp 9929, udp 9929 for booth
+
+TCP="30865 5560 7630 21064 3121 2224 5403 9929"
 
 # space separated list of allowed UDP ports
-UDP=""
+UDP="5404 5405 9929"
 
 # space separated list of allowed RPC services
 RPC=""

--- a/package/yast2-cluster.changes
+++ b/package/yast2-cluster.changes
@@ -1,4 +1,18 @@
 -------------------------------------------------------------------
+Wed Sep 25 06:08:12 UTC 2019 - nick wang <nwang@suse.com>
+
+- bsc#1151687, update the open ports to support pacemaker-remote,
+  booth, corosync-qnetd.
+- Version 3.4.1
+
+-------------------------------------------------------------------
+Mon Jan 14 07:41:14 UTC 2019 - nwang@suse.com
+
+- bsc#1120815, support use hostname in ring address.
+  Only available in SLE12SP3, since from SP4 crmsh use IP.
+- Version 3.4.0
+
+-------------------------------------------------------------------
 Fri Oct 27 08:35:58 UTC 2017 - nwang@suse.com
 
 - bsc#1065393, remove checking bind address when unicast.

--- a/package/yast2-cluster.spec
+++ b/package/yast2-cluster.spec
@@ -18,7 +18,7 @@
 
 Name:           yast2-cluster
 %define _fwdefdir /etc/sysconfig/SuSEfirewall2.d/services
-Version:        3.3.0
+Version:        3.4.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/cluster/dialogs.rb
+++ b/src/include/cluster/dialogs.rb
@@ -199,7 +199,8 @@ module Yast
       if UI.QueryWidget(Id(:transport), :Value) == "udpu"
         i = 0
         Builtins.foreach(Cluster.memberaddr) do |value|
-          if  !IP.Check(value[:addr1]) || ( UI.QueryWidget(Id(:enable2), :Value) && !IP.Check(value[:addr2]) )
+          if  ( UI.QueryWidget(Id(:addr1), :Value) == "" ) ||
+            ( UI.QueryWidget(Id(:enable2), :Value) && ( UI.QueryWidget(Id(:addr2), :Value) == "" ) )
             UI.ChangeWidget(:memberaddr, :CurrentItem, i)
             i = 0
             raise Break

--- a/src/modules/Cluster.rb
+++ b/src/modules/Cluster.rb
@@ -182,7 +182,7 @@ module Yast
             # 123.3.21.44;156.32.123.9"
             address = SCR.Read(path(".openais.nodelist.node")).split(" ")
             address.each do |addr|
-              p = addr.split("-")
+              p = addr.split("|")
               if p[1] != nil
                 q = p[0].split(";")
                 if q[1] != nil
@@ -249,16 +249,16 @@ module Yast
     end
 
 
-    # BNC#871970, generate string like "123.3.21.32;156.32.123.1:1"
+    # BNC#871970, generate string like "123.3.21.32;156.32.123.1|1"
     def generateMemberString(memberaddr)
       address_string = ""
       memberaddr.each do |i|
         address_string << i[:addr1]
         if i[:addr2]
           address_string << ";#{i[:addr2]}"
-          address_string << "-#{i[:nodeid]}" if i [:nodeid]
+          address_string << "|#{i[:nodeid]}" if i [:nodeid]
         else 
-          address_string << "-#{i[:nodeid]}" if i[:nodeid]
+          address_string << "|#{i[:nodeid]}" if i[:nodeid]
         end
         address_string << " "
       end

--- a/src/servers_non_y2/ag_openais
+++ b/src/servers_non_y2/ag_openais
@@ -425,7 +425,7 @@ def generateMemberString():
 				member_str = member_str + ";" + address2
 			nodeid = item.get("nodeid", None)
 			if nodeid:
-				member_str = member_str + "-" + nodeid
+				member_str = member_str + "|" + nodeid
 			member_str = member_str + " "
 	return '"%s"' % member_str.strip()
 
@@ -715,16 +715,16 @@ class OpenAISConf_Parser:
 						nodelist_options["node"] = member_addr_set
 						return "nil"
 					for member_address in args.strip().split(" "):
-						dash_pos = member_address.find("-")
-						if (dash_pos > -1):
-							tmpid = member_address[dash_pos+1:]
-							semicolon_pos = member_address[:dash_pos].find(";")
+						pipe_pos = member_address.find("|")
+						if (pipe_pos > -1):
+							tmpid = member_address[pipe_pos+1:]
+							semicolon_pos = member_address[:pipe_pos].find(";")
 							if (semicolon_pos > -1):
-								member_addr_set.append({"ring0_addr":member_address[:semicolon_pos],"ring1_addr":member_address[semicolon_pos+1:dash_pos],"nodeid":member_address[dash_pos+1:]})
+								member_addr_set.append({"ring0_addr":member_address[:semicolon_pos],"ring1_addr":member_address[semicolon_pos+1:pipe_pos],"nodeid":member_address[pipe_pos+1:]})
 							else:
-								member_addr_set.append({"ring0_addr":member_address[:dash_pos],"nodeid":member_address[dash_pos+1:]})
+								member_addr_set.append({"ring0_addr":member_address[:pipe_pos],"nodeid":member_address[pipe_pos+1:]})
 						else:
-							semicolon_pos = member_address[:dash_pos].find(";")
+							semicolon_pos = member_address[:pipe_pos].find(";")
 							if (semicolon_pos > -1):
 								member_addr_set.append({"ring0_addr":member_address[:semicolon_pos],"ring1_addr":member_address[semicolon_pos+1:]})
 							else:


### PR DESCRIPTION
bsc#1151687, update the open ports to support pacemaker-remote, booth and corosync-qnetd

The package version of SLE12SP3 is in correct, which will cause trouble when upgrading to SP4 and SP5... So also bump up version in SLE12SP4/SP5. In SLE15, everything back to normal.

Actually, the fix `1f99b2c` could exist in SP4 and SP5, so leave it without a revert.