### PR TITLE
sle15ga, bsc#1151687

### DIFF
--- a/package/cluster.firewalld.xml
+++ b/package/cluster.firewalld.xml
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <service>
   <short>SUSE YaST Cluster</short>
-  <description>This allows you to open various ports related to SUSE YaST Cluster module. Ports are opened for mgmtd, hawk, dlm and csync2.</description>
+  <description>This allows you to open various ports related to SUSE YaST Cluster module. Ports are opened for pacemaker-remote, booth, mgmtd, hawk, dlm, csync2 and corosync-qnetd.</description>
+  <port protocol="tcp" port="2224"/>
+  <port protocol="tcp" port="3121"/>
+  <port protocol="tcp" port="5403"/>
+  <port protocol="udp" port="5404"/>
+  <port protocol="udp" port="5405"/>
   <port protocol="tcp" port="5560"/>
   <port protocol="tcp" port="7630"/>
+  <port protocol="tcp" port="9929"/>
+  <port protocol="udp" port="9929"/>
   <port protocol="tcp" port="21064"/>
   <port protocol="tcp" port="30865"/>
 </service>

--- a/package/yast2-cluster.changes
+++ b/package/yast2-cluster.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep 25 07:06:51 UTC 2019 - nick wang <nwang@suse.com>
+
+- bsc#1151687, update the open ports to support pacemaker-remote,
+  booth and corosync-qnetd.
+- Version 4.0.9
+
+-------------------------------------------------------------------
 Tue Apr 23 15:50:05 UTC 2019 - Stefan Weiberg <sweiberg@suse.com>
 
 - bsc#1132881, uuencode can't be executed if sharutils are not

--- a/package/yast2-cluster.spec
+++ b/package/yast2-cluster.spec
@@ -18,7 +18,7 @@
 
 Name:           yast2-cluster
 %define _fwdefdir %{_libexecdir}/firewalld/services
-Version:        4.0.8
+Version:        4.0.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
bsc#1151687, update the open ports to support pacemaker-remote, booth and corosync-qnetd
