### PR TITLE
Master bsc#1151687

### DIFF
--- a/package/cluster.firewalld.xml
+++ b/package/cluster.firewalld.xml
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <service>
   <short>SUSE YaST Cluster</short>
-  <description>This allows you to open various ports related to SUSE YaST Cluster module. Ports are opened for mgmtd, hawk, dlm and csync2.</description>
+  <description>This allows you to open various ports related to SUSE YaST Cluster module. Ports are opened for pacemaker-remote, booth, mgmtd, hawk, dlm, csync2 and corosync-qnetd.</description>
+  <port protocol="tcp" port="2224"/>
+  <port protocol="tcp" port="3121"/>
+  <port protocol="tcp" port="5403"/>
+  <port protocol="udp" port="5404"/>
+  <port protocol="udp" port="5405"/>
   <port protocol="tcp" port="5560"/>
   <port protocol="tcp" port="7630"/>
+  <port protocol="tcp" port="9929"/>
+  <port protocol="udp" port="9929"/>
   <port protocol="tcp" port="21064"/>
   <port protocol="tcp" port="30865"/>
 </service>

--- a/package/yast2-cluster.changes
+++ b/package/yast2-cluster.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep 25 07:06:51 UTC 2019 - nick wang <nwang@suse.com>
+
+- bsc#1151687, update the open ports to support pacemaker-remote,
+  booth and corosync-qnetd.
+- Version 4.2.4
+
+-------------------------------------------------------------------
 Thu Aug 22 14:40:16 CEST 2019 - schubi@suse.de
 
 - Using rb_default_ruby_abi tag in the spec file in order to

--- a/package/yast2-cluster.spec
+++ b/package/yast2-cluster.spec
@@ -18,7 +18,7 @@
 %define _fwdefdir %{_libexecdir}/firewalld/services
 
 Name:           yast2-cluster
-Version:        4.2.3
+Version:        4.2.4
 Release:        0
 Summary:        Configuration of cluster
 License:        GPL-2.0-only
@@ -33,6 +33,7 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake)
 BuildRequires:  update-desktop-files
 BuildRequires:  yast2-devtools >= 4.2.2
 
+Requires:       yast2 >= 4.0.39
 Requires:       yast2-ruby-bindings >= 1.0.0
 Requires:       yast2 >= 4.1.3
 


### PR DESCRIPTION
bsc#1151687, update the open ports to support pacemaker-remote, booth and corosync-qnetd.