### PR TITLE
Fix packaging: do not rely on libexecdir pointing to /usr/lib (bsc#1174075)

### DIFF
--- a/package/yast2-cluster.changes
+++ b/package/yast2-cluster.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul 23 10:48:14 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- RPM Packaging: do not rely on libexecdir being expanded to
+  /usr/lib, which is not always the case (bsc#1174075).
+- Version 4.3.0
+
+-------------------------------------------------------------------
 Mon Apr 13 06:49:43 UTC 2020 - nick wang <nwang@suse.com>
 
 - jsc#SLE-12432, add qdevice heuristics support

--- a/package/yast2-cluster.spec
+++ b/package/yast2-cluster.spec
@@ -18,7 +18,7 @@
 %define _fwdefdir %{_libexecdir}/firewalld/services
 
 Name:           yast2-cluster
-Version:        4.2.6
+Version:        4.3.0
 Release:        0
 Summary:        Configuration of cluster
 License:        GPL-2.0-only

--- a/package/yast2-cluster.spec
+++ b/package/yast2-cluster.spec
@@ -63,7 +63,7 @@ install -D -m 0644 %{S:1} %{buildroot}%{_fwdefdir}/cluster.xml
 %{yast_metainfodir}
 %{yast_scrconfdir}
 %{yast_agentdir}
-%dir %{_libexecdir}/firewalld
+%dir %{_prefix}/lib/firewalld
 %dir %{_fwdefdir}
 %{_fwdefdir}/cluster.xml
 %{yast_icondir}


### PR DESCRIPTION
## Problem

This package includes a `/usr/lib/firewalld` directory. In the spec file that was specified as `%{_libexecdir}/firewalld` because (open)SUSE used to expand `%{_libexecdir}` as `/usr/lib` (there was not provision for `%_libexecdir` in older versions of the [FHS](https://www.pathname.com/fhs/)).

But FHS 3.0 defines that `%_libexecdir` must be expanded as `/usr/libexec` and openSUSE Tumbleweed is being adapted to honor that. Thus, the previous way of specifying `/usr/lib/firewalld` on this package would not longer be valid.

## Solution

Use `%{_prefix}/lib/firewalld` that should be correctly expanded as `/usr/lib/firewalld" in all versions of (open)SUSE.