### PR TITLE
Correct firewall directory for %_libexecdir changes (bsc#1174075)

### DIFF
--- a/package/yast2-cluster.changes
+++ b/package/yast2-cluster.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 19 09:51:43 UTC 2020 - Callum Farmer <callumjfarmer13@gmail.com>
+
+- Correct firewall directory for %_libexecdir changes (bsc#1174075)
+- Version 4.3.2
+
+-------------------------------------------------------------------
 Mon Aug 10 17:05:37 CEST 2020 - schubi@suse.de
 
 - AutoYaST: Added supplements: autoyast(cluster) into the spec file

--- a/package/yast2-cluster.spec
+++ b/package/yast2-cluster.spec
@@ -15,10 +15,10 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
-%define _fwdefdir %{_libexecdir}/firewalld/services
+%define _fwdefdir %{_prefix}/lib/firewalld/services
 
 Name:           yast2-cluster
-Version:        4.3.1
+Version:        4.3.2
 Release:        0
 Summary:        Configuration of cluster
 License:        GPL-2.0-only


### PR DESCRIPTION
- Fixes for %_libexecdir changing to /usr/libexec (bsc#1174075)