### PR TITLE
Fix UI label switch to turn off csync2 service

### DIFF
--- a/package/yast2-cluster.changes
+++ b/package/yast2-cluster.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Aug 25 01:18:40 UTC 2020 - nick wang <nwang@suse.com>
+
+- bsc#1175648, fix UI label switch to turn off csync2 service
+- Version 4.2.7
+
+-------------------------------------------------------------------
 Mon Apr 13 06:49:43 UTC 2020 - nick wang <nwang@suse.com>
 
 - jsc#SLE-12432, add qdevice heuristics support

--- a/package/yast2-cluster.spec
+++ b/package/yast2-cluster.spec
@@ -18,7 +18,7 @@
 %define _fwdefdir %{_libexecdir}/firewalld/services
 
 Name:           yast2-cluster
-Version:        4.2.6
+Version:        4.2.7
 Release:        0
 Summary:        Configuration of cluster
 License:        GPL-2.0-only

--- a/src/include/cluster/dialogs.rb
+++ b/src/include/cluster/dialogs.rb
@@ -1480,10 +1480,11 @@ module Yast
         firewalld_cluster = firewalld.find_service("cluster")
         tcp_ports = firewalld_cluster.tcp_ports
       rescue Y2Firewall::Firewalld::Service::NotFound
-        tcp_ports = []
+        y2debug("Firewalld service not found.")
+        return 3
       end
 
-      tcp_ports.include?(@csync2_port) ? 2 : 3
+      tcp_ports.include?(@csync2_port) ? 3 : 2
     end
 
     def csync2_turn_off


### PR DESCRIPTION
bsc#1175648, unable to turn off csync2 service.
Fix the incorrect return number when firewalld enabled.

follow up merge request of https://github.com/yast/yast-cluster/pull/82