### PR TITLE
bsc#1179007 and bsc#1179420, Bind address should not write to configuration file when using unicast and support enable secauth

### DIFF
--- a/package/yast2-cluster.changes
+++ b/package/yast2-cluster.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Dec 02 01:17:23 UTC 2020 - nick wang <nwang@suse.com>
+
+- bsc#1179420, fix secauth and support crypto_cipher/crypto_hash
+- Version 4.2.10
+
+-------------------------------------------------------------------
 Mon Nov 23 08:15:12 UTC 2020 - nick wang <nwang@suse.com>
 
 - bsc#1179007, not to write bind address when unicast

--- a/package/yast2-cluster.changes
+++ b/package/yast2-cluster.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Nov 23 08:15:12 UTC 2020 - nick wang <nwang@suse.com>
+
+- bsc#1179007, not to write bind address when unicast
+- Fix fail to configure ttl for the second ring
+- Version 4.2.9
+
+-------------------------------------------------------------------
 Tue Nov  3 05:08:44 UTC 2020 - nick wang <nwang@suse.com>
 
 - bsc#1178373, include "/etc/sysconfig/nfs" into csync2.cfg

--- a/package/yast2-cluster.spec
+++ b/package/yast2-cluster.spec
@@ -18,7 +18,7 @@
 %define _fwdefdir %{_libexecdir}/firewalld/services
 
 Name:           yast2-cluster
-Version:        4.2.9
+Version:        4.2.10
 Release:        0
 Summary:        Configuration of cluster
 License:        GPL-2.0-only

--- a/package/yast2-cluster.spec
+++ b/package/yast2-cluster.spec
@@ -18,7 +18,7 @@
 %define _fwdefdir %{_libexecdir}/firewalld/services
 
 Name:           yast2-cluster
-Version:        4.2.8
+Version:        4.2.9
 Release:        0
 Summary:        Configuration of cluster
 License:        GPL-2.0-only

--- a/src/include/cluster/dialogs.rb
+++ b/src/include/cluster/dialogs.rb
@@ -725,18 +725,10 @@ module Yast
       ret
     end
 
-    def SaveSecurityToConf
-      if UI.QueryWidget(Id(:secauth), :Value) == true
-        SCR.Write(path(".openais.totem.secauth"), "on")
-      else
-        SCR.Write(path(".openais.totem.secauth"), "off")
-      end
-
-      nil
-    end
-
     def SaveSecurity
       Cluster.secauth = Convert.to_boolean(UI.QueryWidget(Id(:secauth), :Value))
+      Cluster.crypto_hash = UI.QueryWidget(Id(:crypto_hash), :Value).to_s
+      Cluster.crypto_cipher = UI.QueryWidget(Id(:crypto_cipher), :Value).to_s
 
       nil
     end
@@ -1083,6 +1075,19 @@ module Yast
           _("Enable Security Auth"),
           true,
           VBox(
+            HBox(
+              HSpacing(20),
+              Left(ComboBox(
+                Id(:crypto_hash), Opt(:hstretch, :notify), _("Crypto Hash:"),
+                ["sha1", "sha256", "sha384", "sha512", "md5"]
+              )),
+              HSpacing(5),
+              Left(ComboBox(
+                Id(:crypto_cipher), Opt(:hstretch, :notify), _("Crypto Cipher:"),
+                ["aes256", "aes192", "aes128", "3des"]
+              )),
+              HSpacing(20),
+            ),
             Label(
               _(
                 "For a newly created cluster, push the button below to generate /etc/corosync/authkey."
@@ -1102,6 +1107,8 @@ module Yast
       my_SetContents("security", contents)
 
       UI.ChangeWidget(Id(:secauth), :Value, Cluster.secauth)
+      UI.ChangeWidget(Id(:crypto_hash), :Value, Cluster.crypto_hash)
+      UI.ChangeWidget(Id(:crypto_cipher), :Value, Cluster.crypto_cipher)
 
       while true
         ret = UI.UserInput
@@ -1122,7 +1129,7 @@ module Yast
           next
         end
 
-        if ret == :secauth
+        if ret == :secauth || ret == :crypto_cipher || ret == :crypto_hash
           if UI.QueryWidget(Id(:secauth), :Value) == true
             next
           end

--- a/src/include/cluster/dialogs.rb
+++ b/src/include/cluster/dialogs.rb
@@ -414,15 +414,17 @@ module Yast
       udp = UI.QueryWidget(Id(:transport), :Value) == "udp"
       enable2 = UI.QueryWidget(Id(:enable2), :Value)
 
-      enable1 = udp
-      enable2 = udp && enable2
+      UI.ChangeWidget(Id(:enable2_vbox), :Enabled, enable2)
+      UI.ChangeWidget(Id(:mcastport2), :Enabled, enable2)
 
-      UI.ChangeWidget(Id(:mcastaddr1), :Enabled, enable1)
+      enable1_addr = udp
+      enable2_addr = udp && enable2
 
-      UI.ChangeWidget(Id(:mcastaddr2), :Enabled, enable2)
+      UI.ChangeWidget(Id(:mcastaddr1), :Enabled, enable1_addr)
+      UI.ChangeWidget(Id(:mcastaddr2), :Enabled, enable2_addr)
 
-      UI.ChangeWidget(Id(:bindnetaddr1), :Enabled, enable1)
-      UI.ChangeWidget(Id(:bindnetaddr2), :Enabled, enable2)
+      UI.ChangeWidget(Id(:bindnetaddr1), :Enabled, enable1_addr)
+      UI.ChangeWidget(Id(:bindnetaddr2), :Enabled, enable2_addr)
 
       ip = UI.QueryWidget(Id(:ip_version), :Value).to_s
       if ip == "ipv6"
@@ -509,12 +511,15 @@ module Yast
         )
       )
 
+      #Refer to https://bugzilla.suse.com/show_bug.cgi?id=1179007
+      #for the reason of option ":noAutoEnable"
       riface = CheckBoxFrame(
         Id(:enable2),
-        Opt(:notify),
+        Opt(:noAutoEnable, :notify),
         _("Redundant Channel"),
         false,
         VBox(
+          Id(:enable2_vbox),
           ComboBox(
             Id(:bindnetaddr2),
             Opt(:editable, :hstretch, :notify),

--- a/src/modules/Cluster.rb
+++ b/src/modules/Cluster.rb
@@ -433,16 +433,17 @@ module Yast
       else
         if @transport == "udpu"
           SCR.Write(path(".openais.totem.interface.interface1.mcastaddr"), "")
+          SCR.Write(path(".openais.totem.interface.interface1.bindnetaddr"), "")
         else
           SCR.Write(
             path(".openais.totem.interface.interface1.mcastaddr"),
             @mcastaddr2
           )
+          SCR.Write(
+            path(".openais.totem.interface.interface1.bindnetaddr"),
+            @bindnetaddr2
+          )
         end
-        SCR.Write(
-          path(".openais.totem.interface.interface1.bindnetaddr"),
-          @bindnetaddr2
-        )
         SCR.Write(
           path(".openais.totem.interface.interface1.mcastport"),
           @mcastport2

--- a/src/modules/Cluster.rb
+++ b/src/modules/Cluster.rb
@@ -65,6 +65,8 @@ module Yast
 
       # Settings: Define all variables needed for configuration of cluster
       @secauth = false
+      @crypto_hash = "none"
+      @crypto_cipher = "none"
       @cluster_name = ""
       @ip_version = ""
       @expected_votes = ""
@@ -219,6 +221,8 @@ module Yast
 
       if Convert.to_string(SCR.Read(path(".openais.totem.secauth"))) == "on"
         @secauth = true
+        @crypto_hash = SCR.Read(path(".openais.totem.crypto_hash"))
+        @crypto_cipher = SCR.Read(path(".openais.totem.crypto_cipher"))
       else
         @secauth = false
       end
@@ -378,8 +382,12 @@ module Yast
 
       if @secauth == true
         SCR.Write(path(".openais.totem.secauth"), "on")
+        SCR.Write(path(".openais.totem.crypto_hash"), @crypto_hash)
+        SCR.Write(path(".openais.totem.crypto_cipher"), @crypto_cipher)
       else
         SCR.Write(path(".openais.totem.secauth"), "off")
+        SCR.Write(path(".openais.totem.crypto_hash"), "none")
+        SCR.Write(path(".openais.totem.crypto_cipher"), "none")
       end
 
       SCR.Write(path(".openais.totem.transport"), @transport)
@@ -734,6 +742,8 @@ module Yast
     def Import(settings)
       settings = deep_copy(settings)
       @secauth = Ops.get_boolean(settings, "secauth", false)
+      @crypto_hash = settings["crypto_hash"] || "none"
+      @crypto_cipher = settings["crypto_cipher"] || "none"
       @transport = Ops.get_string(settings, "transport", "udp")
       @bindnetaddr1 = Ops.get_string(settings, "bindnetaddr1", "")
       @memberaddr = Ops.get_list(settings, "memberaddr", [])
@@ -783,6 +793,8 @@ module Yast
     def Export
       result = {}
       Ops.set(result, "secauth", @secauth)
+      Ops.set(result, "crypto_hash", @crypto_hash)
+      Ops.set(result, "crypto_cipher", @crypto_cipher)
       Ops.set(result, "transport", @transport)
       Ops.set(result, "bindnetaddr1", @bindnetaddr1)
       Ops.set(result, "memberaddr", @memberaddr)
@@ -895,6 +907,8 @@ module Yast
     publish :function => :SetWriteOnly, :type => "void (boolean)"
     publish :function => :SetAbortFunction, :type => "void (boolean ())"
     publish :variable => :secauth, :type => "boolean"
+    publish :variable => :crypto_hash, :type => "string"
+    publish :variable => :crypto_cipher, :type => "string"
     publish :variable => :bindnetaddr1, :type => "string"
     publish :variable => :mcastaddr1, :type => "string"
     publish :variable => :cluster_name, :type => "string"

--- a/src/servers_non_y2/ag_openais
+++ b/src/servers_non_y2/ag_openais
@@ -720,7 +720,7 @@ class OpenAISConf_Parser(object):
 								return '"%s"' % i.get("mcastaddr", "")
 							elif path[3] == "mcastport":
 								return '"%d"' % i.get("mcastport", 5405)
-							if path[3] == "ttl":
+							elif path[3] == "ttl":
 								return '"%d"' % i.get("ttl", 1)
 							else:
 								return "nil"
@@ -735,6 +735,8 @@ class OpenAISConf_Parser(object):
 								return '"%s"' % i.get("mcastaddr", "")
 							elif path[3] == "mcastport":
 								return '"%d"' % i.get("mcastport", 5405)
+							elif path[3] == "ttl":
+								return '"%d"' % i.get("ttl", 1)
 							else:
 								return "nil"
 					elif path[2] == "member":

--- a/src/servers_non_y2/ag_openais
+++ b/src/servers_non_y2/ag_openais
@@ -691,6 +691,10 @@ class OpenAISConf_Parser(object):
 			elif len(path) == 2:
 				if path[1] == "secauth":
 					return '"%s"' % totem_options.get("secauth", "")
+				elif path[1] == "crypto_hash":
+					return '"%s"' % totem_options.get("crypto_hash", "none")
+				elif path[1] == "crypto_cipher":
+					return '"%s"' % totem_options.get("crypto_cipher", "none")
 				elif path[1] == "autoid":
 					#FIXME, check nodelist has nodeid
 					for i in nodelist_options.get('node'):
@@ -854,6 +858,12 @@ class OpenAISConf_Parser(object):
 					return "true"
 				elif path[1] == "secauth":
 					totem_options["secauth"] = args
+					return "true"
+				elif path[1] == "crypto_hash":
+					totem_options["crypto_hash"] = args
+					return "true"
+				elif path[1] == "crypto_cipher":
+					totem_options["crypto_cipher"] = args
 					return "true"
 				elif path[1] == "rrpmode":
 					totem_options["rrp_mode"] = args


### PR DESCRIPTION
bsc#1179007, Do not write the bind address to configuration file when unicast.
Fix issue of configure ttl of the second ring.
bsc#1179420, fix secauth and support crypto_cipher/crypto_hash