### PR TITLE
bsc#1180424, add watchdog.conf to csync2 default list

### DIFF
--- a/package/yast2-cluster.changes
+++ b/package/yast2-cluster.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue Jan  5 08:24:53 UTC 2021 - nick wang <nwang@suse.com>
+
+- bsc#1180424, add watchdog.conf to csync2 default list
+- bsc#1151687, update the open ports to support pacemaker-remote,
+  booth, corosync-qnetd.
+- bsc#1120815, support use hostname in ring address.
+- Version 4.1.7
+
+-------------------------------------------------------------------
 Tue Aug 25 01:18:40 UTC 2020 - nick wang <nwang@suse.com>
 
 - bsc#1175648, fix UI label switch to turn off csync2 service

--- a/package/yast2-cluster.spec
+++ b/package/yast2-cluster.spec
@@ -18,7 +18,7 @@
 
 %define _fwdefdir %{_libexecdir}/firewalld/services
 Name:           yast2-cluster
-Version:        4.1.6
+Version:        4.1.7
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/cluster/dialogs.rb
+++ b/src/include/cluster/dialogs.rb
@@ -60,7 +60,8 @@ module Yast
         "/etc/booth",
         "/etc/sysconfig/sbd",
         "/etc/csync2/csync2.cfg",
-        "/etc/csync2/key_hagroup"
+        "/etc/csync2/key_hagroup",
+        "/etc/modules-load.d/watchdog.conf"
       ]
 
       @csync2_port = "30865"
@@ -204,7 +205,29 @@ module Yast
         return false
       end
 
-      if UI.QueryWidget(Id(:transport), :Value) == "udp"
+      if UI.QueryWidget(Id(:transport), :Value) == "udpu"
+        i = 0
+        Builtins.foreach(Cluster.memberaddr) do |value|
+          if  ( UI.QueryWidget(Id(:addr1), :Value) == "" ) ||
+            ( UI.QueryWidget(Id(:enable2), :Value) && ( UI.QueryWidget(Id(:addr2), :Value) == "" ) )
+            UI.ChangeWidget(:memberaddr, :CurrentItem, i)
+            i = 0
+            raise Break
+          end
+          i = Ops.add(i, 1)
+        end
+        if i == 0
+          UI.SetFocus(:memberaddr)
+          Popup.Message(_("The Member Address has to be fulfilled"))
+          return false
+        end
+      else
+        #BNC#880242, expected_votes must have value when "udp"
+        if UI.QueryWidget(Id(:expected_votes), :Value) == ""
+          Popup.Message(_("The Expected Votes has to be fulfilled when multicast transport is configured"))
+          UI.SetFocus(:expected_votes)
+          return false
+        end
 
         if !ip_matching_check(UI.QueryWidget(Id(:bindnetaddr1), :Value), ip_version)
           Popup.Message(_("IP Version doesn't match with Bind Network Address in Channel"))

--- a/src/modules/Cluster.rb
+++ b/src/modules/Cluster.rb
@@ -242,8 +242,9 @@ module Yast
             # memberaddr of udpu only read in interface0
             # address is like "123.3.21.32;156.32.123.1:1 123.3.21.54;156.32.123.4:2 
             # 123.3.21.44;156.32.123.9"
-            @address.each do |addr|
-              p = addr.split("-")
+            address = SCR.Read(path(".openais.nodelist.node")).split(" ")
+            address.each do |addr|
+              p = addr.split("|")
               if p[1] != nil
                 q = p[0].split(";")
                 if q[1] != nil
@@ -313,16 +314,16 @@ module Yast
     end
 
 
-    # BNC#871970, generate string like "123.3.21.32;156.32.123.1:1"
+    # BNC#871970, generate string like "123.3.21.32;156.32.123.1|1"
     def generateMemberString(memberaddr)
       address_string = ""
       memberaddr.each do |i|
         address_string << i[:addr1]
         if i[:addr2]
           address_string << ";#{i[:addr2]}"
-          address_string << "-#{i[:nodeid]}" if i [:nodeid]
+          address_string << "|#{i[:nodeid]}" if i [:nodeid]
         else 
-          address_string << "-#{i[:nodeid]}" if i[:nodeid]
+          address_string << "|#{i[:nodeid]}" if i[:nodeid]
         end
         address_string << " "
       end

--- a/src/servers_non_y2/ag_openais
+++ b/src/servers_non_y2/ag_openais
@@ -556,7 +556,7 @@ def generateMemberString():
 				member_str = member_str + ";" + address2
 			nodeid = item.get("nodeid", None)
 			if nodeid:
-				member_str = member_str + "-" + nodeid
+				member_str = member_str + "|" + nodeid
 			member_str = member_str + " "
 	return '"%s"' % member_str.strip()
 
@@ -935,16 +935,16 @@ class OpenAISConf_Parser(object):
 						nodelist_options["node"] = member_addr_set
 						return "nil"
 					for member_address in args.strip().split(" "):
-						dash_pos = member_address.find("-")
-						if (dash_pos > -1):
-							tmpid = member_address[dash_pos+1:]
-							semicolon_pos = member_address[:dash_pos].find(";")
+						pipe_pos = member_address.find("|")
+						if (pipe_pos > -1):
+							tmpid = member_address[pipe_pos+1:]
+							semicolon_pos = member_address[:pipe_pos].find(";")
 							if (semicolon_pos > -1):
-								member_addr_set.append({"ring0_addr":member_address[:semicolon_pos],"ring1_addr":member_address[semicolon_pos+1:dash_pos],"nodeid":member_address[dash_pos+1:]})
+								member_addr_set.append({"ring0_addr":member_address[:semicolon_pos],"ring1_addr":member_address[semicolon_pos+1:pipe_pos],"nodeid":member_address[pipe_pos+1:]})
 							else:
-								member_addr_set.append({"ring0_addr":member_address[:dash_pos],"nodeid":member_address[dash_pos+1:]})
+								member_addr_set.append({"ring0_addr":member_address[:pipe_pos],"nodeid":member_address[pipe_pos+1:]})
 						else:
-							semicolon_pos = member_address[:dash_pos].find(";")
+							semicolon_pos = member_address[:pipe_pos].find(";")
 							if (semicolon_pos > -1):
 								member_addr_set.append({"ring0_addr":member_address[:semicolon_pos],"ring1_addr":member_address[semicolon_pos+1:]})
 							else:


### PR DESCRIPTION
- bsc#1180424, add watchdog.conf to csync2 default list
- bsc#1151687, update the open ports to support pacemaker-remote,
  booth, corosync-qnetd.
- bsc#1120815, support use hostname in ring address.
- Version 4.1.7