### PR TITLE
bsc#1180424, add watchdog.conf to csync2 default list

### DIFF
--- a/package/yast2-cluster.changes
+++ b/package/yast2-cluster.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue Jan  5 08:24:53 UTC 2021 - nick wang <nwang@suse.com>
+
+- bsc#1180424, add watchdog.conf to csync2 default list
+- bsc#1151687, update the open ports to support pacemaker-remote,
+  booth, corosync-qnetd.
+- bsc#1120815, support use hostname in ring address.
+- Version 4.3.6
+
+-------------------------------------------------------------------
 Mon Dec 02 01:17:23 UTC 2020 - nick wang <nwang@suse.com>
 
 - bsc#1179420, fix secauth and support crypto_cipher/crypto_hash

--- a/package/yast2-cluster.spec
+++ b/package/yast2-cluster.spec
@@ -18,7 +18,7 @@
 %define _fwdefdir %{_prefix}/lib/firewalld/services
 
 Name:           yast2-cluster
-Version:        4.3.5
+Version:        4.3.6
 Release:        0
 Summary:        Configuration of cluster
 License:        GPL-2.0-only

--- a/src/modules/Cluster.rb
+++ b/src/modules/Cluster.rb
@@ -247,8 +247,9 @@ module Yast
             # memberaddr of udpu only read in interface0
             # address is like "123.3.21.32;156.32.123.1:1 123.3.21.54;156.32.123.4:2 
             # 123.3.21.44;156.32.123.9"
-            @address.each do |addr|
-              p = addr.split("-")
+            address = SCR.Read(path(".openais.nodelist.node")).split(" ")
+            address.each do |addr|
+              p = addr.split("|")
               if p[1] != nil
                 q = p[0].split(";")
                 if q[1] != nil
@@ -318,16 +319,16 @@ module Yast
     end
 
 
-    # BNC#871970, generate string like "123.3.21.32;156.32.123.1:1"
+    # BNC#871970, generate string like "123.3.21.32;156.32.123.1|1"
     def generateMemberString(memberaddr)
       address_string = ""
       memberaddr.each do |i|
         address_string << i[:addr1]
         if i[:addr2]
           address_string << ";#{i[:addr2]}"
-          address_string << "-#{i[:nodeid]}" if i [:nodeid]
+          address_string << "|#{i[:nodeid]}" if i [:nodeid]
         else 
-          address_string << "-#{i[:nodeid]}" if i[:nodeid]
+          address_string << "|#{i[:nodeid]}" if i[:nodeid]
         end
         address_string << " "
       end

--- a/src/servers_non_y2/ag_openais
+++ b/src/servers_non_y2/ag_openais
@@ -556,7 +556,7 @@ def generateMemberString():
 				member_str = member_str + ";" + address2
 			nodeid = item.get("nodeid", None)
 			if nodeid:
-				member_str = member_str + "-" + nodeid
+				member_str = member_str + "|" + nodeid
 			member_str = member_str + " "
 	return '"%s"' % member_str.strip()
 
@@ -947,16 +947,16 @@ class OpenAISConf_Parser(object):
 						nodelist_options["node"] = member_addr_set
 						return "nil"
 					for member_address in args.strip().split(" "):
-						dash_pos = member_address.find("-")
-						if (dash_pos > -1):
-							tmpid = member_address[dash_pos+1:]
-							semicolon_pos = member_address[:dash_pos].find(";")
+						pipe_pos = member_address.find("|")
+						if (pipe_pos > -1):
+							tmpid = member_address[pipe_pos+1:]
+							semicolon_pos = member_address[:pipe_pos].find(";")
 							if (semicolon_pos > -1):
-								member_addr_set.append({"ring0_addr":member_address[:semicolon_pos],"ring1_addr":member_address[semicolon_pos+1:dash_pos],"nodeid":member_address[dash_pos+1:]})
+								member_addr_set.append({"ring0_addr":member_address[:semicolon_pos],"ring1_addr":member_address[semicolon_pos+1:pipe_pos],"nodeid":member_address[pipe_pos+1:]})
 							else:
-								member_addr_set.append({"ring0_addr":member_address[:dash_pos],"nodeid":member_address[dash_pos+1:]})
+								member_addr_set.append({"ring0_addr":member_address[:pipe_pos],"nodeid":member_address[pipe_pos+1:]})
 						else:
-							semicolon_pos = member_address[:dash_pos].find(";")
+							semicolon_pos = member_address[:pipe_pos].find(";")
 							if (semicolon_pos > -1):
 								member_addr_set.append({"ring0_addr":member_address[:semicolon_pos],"ring1_addr":member_address[semicolon_pos+1:]})
 							else:


### PR DESCRIPTION
- bsc#1180424, add watchdog.conf to csync2 default list
- bsc#1151687, update the open ports to support pacemaker-remote,
  booth, corosync-qnetd.
- bsc#1120815, support use hostname in ring address.
- Version 4.3.6