### PR TITLE
[SLE-12-SP5] Set crypto_hash as "sha1" and set crypto_cipher as "aes256" and other changes

### DIFF
--- a/package/yast2-cluster.changes
+++ b/package/yast2-cluster.changes
@@ -1,4 +1,15 @@
 -------------------------------------------------------------------
+Sat Oct 29 14:15:06 UTC 2022 - XinLiang <XLiang@suse.com>
+
+- bsc#1204530, set crypto_hash as "sha1" and set crypto_cipher as "aes256",
+- Set transport as "udpu" when detect in cloud,
+- Set default values for mcastaddr/mcastport/bindnedaddr when cluster firstly configured
+- Set focus on "Generate Auth Key File" when secauth is true
+- Implement ValidateSecurity method
+- Set focus on memberaddr add when using udpu
+- Version 3.4.3
+
+-------------------------------------------------------------------
 Tue Jan  5 08:24:53 UTC 2021 - nick wang <nwang@suse.com>
 
 - bsc#1180424, add watchdog.conf to csync2 default list

--- a/package/yast2-cluster.spec
+++ b/package/yast2-cluster.spec
@@ -18,7 +18,7 @@
 
 Name:           yast2-cluster
 %define _fwdefdir /etc/sysconfig/SuSEfirewall2.d/services
-Version:        3.4.2
+Version:        3.4.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/cluster/dialogs.rb
+++ b/src/include/cluster/dialogs.rb
@@ -542,6 +542,9 @@ module Yast
         UI.ChangeWidget(Id(:rrpmode), :Enabled, true)
       end
 
+      if UI.QueryWidget(Id(:transport), :Value) == "udpu"
+        UI.SetFocus(:memberaddr_add)
+      end
       # BNC#879596, check the corosync.conf format
       if Cluster.config_format == "old"
         Popup.Message(_(" NOTICE: Detected old corosync configuration.\n Please reconfigure the member list and confirm all other settings."))

--- a/src/include/cluster/dialogs.rb
+++ b/src/include/cluster/dialogs.rb
@@ -717,12 +717,12 @@ module Yast
               HSpacing(20),
               Left(ComboBox(
                 Id(:crypto_hash), Opt(:hstretch, :notify), _("Crypto Hash:"),
-                ["sha1", "sha256", "sha384", "sha512", "md5"]
+                ["sha1", "sha256", "sha384", "sha512", "md5", "none"]
               )),
               HSpacing(5),
               Left(ComboBox(
                 Id(:crypto_cipher), Opt(:hstretch, :notify), _("Crypto Cipher:"),
-                ["aes256", "aes192", "aes128", "3des"]
+                ["aes256", "aes192", "aes128", "3des", "none"]
               )),
               HSpacing(20),
             ),

--- a/src/include/cluster/dialogs.rb
+++ b/src/include/cluster/dialogs.rb
@@ -694,18 +694,10 @@ module Yast
       ret
     end
 
-    def SaveSecurityToConf
-      if UI.QueryWidget(Id(:secauth), :Value) == true
-        SCR.Write(path(".openais.totem.secauth"), "on")
-      else
-        SCR.Write(path(".openais.totem.secauth"), "off")
-      end
-
-      nil
-    end
-
     def SaveSecurity
       Cluster.secauth = Convert.to_boolean(UI.QueryWidget(Id(:secauth), :Value))
+      Cluster.crypto_hash = UI.QueryWidget(Id(:crypto_hash), :Value).to_s
+      Cluster.crypto_cipher = UI.QueryWidget(Id(:crypto_cipher), :Value).to_s
 
       nil
     end
@@ -721,6 +713,19 @@ module Yast
           _("Enable Security Auth"),
           true,
           VBox(
+            HBox(
+              HSpacing(20),
+              Left(ComboBox(
+                Id(:crypto_hash), Opt(:hstretch, :notify), _("Crypto Hash:"),
+                ["sha1", "sha256", "sha384", "sha512", "md5"]
+              )),
+              HSpacing(5),
+              Left(ComboBox(
+                Id(:crypto_cipher), Opt(:hstretch, :notify), _("Crypto Cipher:"),
+                ["aes256", "aes192", "aes128", "3des"]
+              )),
+              HSpacing(20),
+            ),
             Label(
               _(
                 "For a newly created cluster, push the button below to generate /etc/corosync/authkey."
@@ -740,6 +745,8 @@ module Yast
       my_SetContents("security", contents)
 
       UI.ChangeWidget(Id(:secauth), :Value, Cluster.secauth)
+      UI.ChangeWidget(Id(:crypto_hash), :Value, Cluster.crypto_hash)
+      UI.ChangeWidget(Id(:crypto_cipher), :Value, Cluster.crypto_cipher)
 
       while true
         ret = UI.UserInput
@@ -760,7 +767,7 @@ module Yast
           next
         end
 
-        if ret == :secauth
+        if ret == :secauth || ret == :crypto_cipher || ret == :crypto_hash
           if UI.QueryWidget(Id(:secauth), :Value) == true
             next
           end

--- a/src/modules/Cluster.rb
+++ b/src/modules/Cluster.rb
@@ -66,6 +66,8 @@ module Yast
 
       # Settings: Define all variables needed for configuration of cluster
       @secauth = false
+      @crypto_hash = "none"
+      @crypto_cipher = "none"
       @cluster_name = ""
       @ip_version = ""
       @expected_votes = ""
@@ -157,6 +159,8 @@ module Yast
 
       if Convert.to_string(SCR.Read(path(".openais.totem.secauth"))) == "on"
         @secauth = true
+        @crypto_hash = SCR.Read(path(".openais.totem.crypto_hash"))
+        @crypto_cipher = SCR.Read(path(".openais.totem.crypto_cipher"))
       else
         @secauth = false
       end
@@ -270,8 +274,12 @@ module Yast
 
       if @secauth == true
         SCR.Write(path(".openais.totem.secauth"), "on")
+        SCR.Write(path(".openais.totem.crypto_hash"), @crypto_hash)
+        SCR.Write(path(".openais.totem.crypto_cipher"), @crypto_cipher)
       else
         SCR.Write(path(".openais.totem.secauth"), "off")
+        SCR.Write(path(".openais.totem.crypto_hash"), "none")
+        SCR.Write(path(".openais.totem.crypto_cipher"), "none")
       end
 
       SCR.Write(path(".openais.totem.transport"), @transport)
@@ -616,6 +624,8 @@ module Yast
     def Import(settings)
       settings = deep_copy(settings)
       @secauth = Ops.get_boolean(settings, "secauth", false)
+      @crypto_hash = settings["crypto_hash"] || "none"
+      @crypto_cipher = settings["crypto_cipher"] || "none"
       @transport = Ops.get_string(settings, "transport", "udp")
       @bindnetaddr1 = Ops.get_string(settings, "bindnetaddr1", "")
       @memberaddr = Ops.get_list(settings, "memberaddr", [])
@@ -649,6 +659,8 @@ module Yast
     def Export
       result = {}
       Ops.set(result, "secauth", @secauth)
+      Ops.set(result, "crypto_hash", @crypto_hash)
+      Ops.set(result, "crypto_cipher", @crypto_cipher)
       Ops.set(result, "transport", @transport)
       Ops.set(result, "bindnetaddr1", @bindnetaddr1)
       Ops.set(result, "memberaddr", @memberaddr)
@@ -743,6 +755,8 @@ module Yast
     publish :function => :SetWriteOnly, :type => "void (boolean)"
     publish :function => :SetAbortFunction, :type => "void (boolean ())"
     publish :variable => :secauth, :type => "boolean"
+    publish :variable => :crypto_hash, :type => "string"
+    publish :variable => :crypto_cipher, :type => "string"
     publish :variable => :bindnetaddr1, :type => "string"
     publish :variable => :mcastaddr1, :type => "string"
     publish :variable => :cluster_name, :type => "string"

--- a/src/modules/Cluster.rb
+++ b/src/modules/Cluster.rb
@@ -177,6 +177,26 @@ module Yast
       @transport = "udp" if @transport == nil
 
       interfaces = SCR.Dir(path(".openais.totem.interface"))
+      if interfaces.nil? or interfaces.empty?
+          @mcastaddr1 = Convert.to_string(
+            SCR.Read(path(".openais.totem.interface.interface0.mcastaddr"))
+          )
+          @bindnetaddr1 = Convert.to_string(
+            SCR.Read(path(".openais.totem.interface.interface0.bindnetaddr"))
+          )
+          @mcastaddr2 = Convert.to_string(
+              SCR.Read(path(".openais.totem.interface.interface1.mcastaddr"))
+            )
+          @bindnetaddr2 = Convert.to_string(
+            SCR.Read(path(".openais.totem.interface.interface1.bindnetaddr"))
+          )
+          @mcastport1 = Convert.to_string(
+            SCR.Read(path(".openais.totem.interface.interface0.mcastport"))
+          )
+          @mcastport2 = Convert.to_string(
+            SCR.Read(path(".openais.totem.interface.interface1.mcastport"))
+          )
+      end
       Builtins.foreach(interfaces) do |interface|
         if interface == "interface0"
           if @transport == "udpu"

--- a/src/servers_non_y2/ag_openais
+++ b/src/servers_non_y2/ag_openais
@@ -543,6 +543,10 @@ class OpenAISConf_Parser:
 			elif len(path) == 2:
 				if path[1] == "secauth":
 					return '"%s"' % totem_options.get("secauth", "on")
+				elif path[1] == "crypto_hash":
+					return '"%s"' % totem_options.get("crypto_hash", "none")
+				elif path[1] == "crypto_cipher":
+					return '"%s"' % totem_options.get("crypto_cipher", "none")
 				elif path[1] == "autoid":
 					#FIXME, check nodelist has nodeid
 					for i in nodelist_options.get('node'):
@@ -657,6 +661,12 @@ class OpenAISConf_Parser:
 					return "true"
 				elif path[1] == "secauth":
 					totem_options["secauth"] = args
+					return "true"
+				elif path[1] == "crypto_hash":
+					totem_options["crypto_hash"] = args
+					return "true"
+				elif path[1] == "crypto_cipher":
+					totem_options["crypto_cipher"] = args
 					return "true"
 				elif path[1] == "rrpmode":
 					totem_options["rrp_mode"] = args

--- a/src/servers_non_y2/ag_openais
+++ b/src/servers_non_y2/ag_openais
@@ -83,10 +83,10 @@ totem_option_table = {
 		   "default_value":2,
 		   "suggested_value":2},
 	"crypto_cipher":{"doc":"Used for mutual node authentication",
-		"type":"select[aes256, aes192, aes128 and 3des,none]","default_value":"aes256",
+		"type":"select[aes256, aes192, aes128, 3des, none]","default_value":"aes256",
 		},
 	"crypto_hash":{"doc":"Used for mutual node authentication",
-		"type":"select[none,md5,sha1,sha256,sha384,sha512]","default_value":"sha1",
+		"type":"select[none, md5, sha1, sha256, sha384, sha512]","default_value":"sha1",
 		},
 	"clear_node_high_bit":{"doc":"To make sure the auto-generated nodeid is positive",
 			       "default_value":"yes"},
@@ -544,9 +544,9 @@ class OpenAISConf_Parser:
 				if path[1] == "secauth":
 					return '"%s"' % totem_options.get("secauth", "on")
 				elif path[1] == "crypto_hash":
-					return '"%s"' % totem_options.get("crypto_hash", "none")
+					return '"%s"' % totem_options.get("crypto_hash", "sha1")
 				elif path[1] == "crypto_cipher":
-					return '"%s"' % totem_options.get("crypto_cipher", "none")
+					return '"%s"' % totem_options.get("crypto_cipher", "aes256")
 				elif path[1] == "autoid":
 					#FIXME, check nodelist has nodeid
 					for i in nodelist_options.get('node'):

--- a/src/servers_non_y2/ag_openais
+++ b/src/servers_non_y2/ag_openais
@@ -35,6 +35,38 @@ textdomain("openais")
 #from ycp import *
 import copy
 import sys
+import subprocess
+
+
+def get_stdout_stderr(cmd, input_s=None, shell=True):
+    '''
+    Run a cmd, return (rc, stdout, stderr)
+    '''
+    proc = subprocess.Popen(cmd,
+                            shell=shell,
+                            stdin=input_s and subprocess.PIPE or None,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE)
+    stdout_data, stderr_data = proc.communicate(input_s)
+    return proc.returncode, stdout_data.strip(), stderr_data.strip()
+
+
+def is_in_cloud():
+    rc, _, _ = get_stdout_stderr("rpm -q python3")
+    if rc != 0:
+        return False
+    rc, _, _ = get_stdout_stderr("rpm -q crmsh")
+    if rc != 0:
+        return False
+    # From 12SP4, crmsh is a python3 module, can't use it directly
+    cmd = '/usr/bin/python3 -c "from crmsh import utils; import sys; res=utils.detect_cloud(); sys.exit(0 if res else 1)"'
+    rc, _, _ = get_stdout_stderr(cmd)
+    if rc != 0:
+        return False
+    return True
+
+
+TRANSPORT_DEFAULT = "udpu" if is_in_cloud() else "udp"
 
 
 #the option table is used to parse and write suggested_value if no options are read
@@ -51,16 +83,16 @@ totem_option_table = {
 		   "default_value":2,
 		   "suggested_value":2},
 	"crypto_cipher":{"doc":"Used for mutual node authentication",
-		"type":"select[aes256, aes192, aes128 and 3des,none]","default_value":"none",
+		"type":"select[aes256, aes192, aes128 and 3des,none]","default_value":"aes256",
 		},
 	"crypto_hash":{"doc":"Used for mutual node authentication",
-		"type":"select[none,md5,sha1,sha256,sha384,sha512]","default_value":"none",
+		"type":"select[none,md5,sha1,sha256,sha384,sha512]","default_value":"sha1",
 		},
 	"clear_node_high_bit":{"doc":"To make sure the auto-generated nodeid is positive",
 			       "default_value":"yes"},
 	"cluster_name":{"doc":"This specifies the name of cluster","type":"string","default_value":"cluster"},
 	"secauth":{"doc":"HMAC/SHA1 should be used to authenticate all message",
-		   "default_value":"off"},
+		   "default_value":"on"},
 	"rrp_mode":{"doc":"The mode for redundant ring. None is used when only 1 interface specified, otherwise, only active or passive may be choosen",
 		    "type":"select[none,active,passive]", "default_value":"none"},
 	"netmtu":{"doc":"Size of MTU", "type":"int", "default_value":1500},
@@ -106,7 +138,7 @@ totem_option_table = {
 	"rrp_problem_count_threshhold":{"doc":"The number of times a problem is detected with a link before setting the link faulty.",
 					"type":"int", "default_value":10},
 	"rrp_token_expired_timeout":{"doc":"This specifies the time in milliseconds to increment the problem counter for the redundant ring protocol after not having received a token from all rings for a particular processor.", "type":"int", "default_value":47},
-	"transport":{"doc":"Transport protocol", "type":"select[udp,udpu]","default_value":"udp"},
+	"transport":{"doc":"Transport protocol", "type":"select[udp,udpu]","default_value":TRANSPORT_DEFAULT},
 	"ip_version":{"doc":"Specifies version of IP to use for communication. Value can be one of ipv4 or ipv6.", "type":"select[ipv4,ipv6]","default_value":"ipv4"},
 }
 
@@ -264,7 +296,7 @@ def print_logging_options(f):
 def print_totem_options(f):
 
 	f.write("totem {\n")
-	transport_protocol = totem_options.get("transport", "udp")
+	transport_protocol = totem_options.get("transport", TRANSPORT_DEFAULT)
 	for key in totem_options.keys():
 		if key == "interface":
 			for inf in totem_options["interface"]:
@@ -452,13 +484,6 @@ def load_ais_conf(filename):
 			os.rename(filename, "/etc/corosync/corosync.conf.corrupted");
 		except:
 			pass
-		try:
-			f = open(filename+".example", "r")
-			file_parser(f)
-			f.close()
-			return
-		except:
-			pass
 
 
 class OpenAISConf_Parser:
@@ -517,7 +542,7 @@ class OpenAISConf_Parser:
 				return "nil"
 			elif len(path) == 2:
 				if path[1] == "secauth":
-					return '"%s"' % totem_options.get("secauth", "")
+					return '"%s"' % totem_options.get("secauth", "on")
 				elif path[1] == "autoid":
 					#FIXME, check nodelist has nodeid
 					for i in nodelist_options.get('node'):
@@ -527,7 +552,7 @@ class OpenAISConf_Parser:
 				elif path[1] == "rrpmode":
 					return '"%s"' % totem_options.get("rrp_mode", "none")
 				elif path[1] == "transport":
-					return '"%s"' % totem_options.get("transport", "udp")
+					return '"%s"' % totem_options.get("transport", TRANSPORT_DEFAULT)
 				elif path[1] == "cluster_name":
 					return '"%s"' % totem_options.get("cluster_name", "cluster")
 				elif path[1] == "ip_version":

--- a/src/servers_non_y2/ag_openais
+++ b/src/servers_non_y2/ag_openais
@@ -36,6 +36,14 @@ textdomain("openais")
 import copy
 import sys
 import subprocess
+import random
+
+
+def gen_mcastaddr():
+	return "239.%d.%d.%d" % (
+                random.randint(0, 255),
+                random.randint(0, 255),
+                random.randint(1, 255))
 
 
 def get_stdout_stderr(cmd, input_s=None, shell=True):
@@ -565,34 +573,18 @@ class OpenAISConf_Parser:
 					return "nil"
 			elif len(path) == 4:
 				if path[1] == "interface":
-					if path[2] == "interface0":
-						i = get_interface(0)
-						if i == None:
-							return "nil"
+					if path[2] in ["interface0", "interface1"]:
+						i = get_interface(0 if path[2] == "interface0" else 1)
+						if path[3] == "bindnetaddr":
+                                                        return "nil" if i is None else '"%s"' % i.get("bindnetaddr", "")
+						elif path[3] == "mcastaddr":
+                                                        maddr = gen_mcastaddr()
+                                                        return '"%s"' % maddr if i is None else '"%s"' % i.get("mcastaddr", maddr)
+						elif path[3] == "mcastport":
+                                                        mport = 5405 if path[2] == "interface0" else 5407
+                                                        return '"%d"' % mport if i is None else '"%d"' % i.get("mcastport", mport)
 						else:
-							if path[3] == "bindnetaddr":
-								return '"%s"' % i.get("bindnetaddr", "")
-							elif path[3] == "mcastaddr":
-								return '"%s"' % i.get("mcastaddr", "")
-							elif path[3] == "mcastport":
-								return '"%d"' % i.get("mcastport", 5405)
-							if path[3] == "ttl":
-								return '"%d"' % i.get("ttl", 1)
-							else:
-								return "nil"
-					elif path[2] == "interface1":
-						i = get_interface(1)
-						if i == None:
 							return "nil"
-						else:
-							if path[3] == "bindnetaddr":
-								return '"%s"' % i.get("bindnetaddr", "")
-							elif path[3] == "mcastaddr":
-								return '"%s"' % i.get("mcastaddr", "")
-							elif path[3] == "mcastport":
-								return '"%d"' % i.get("mcastport", 5405)
-							else:
-								return "nil"
 					elif path[2] == "member":
 						return '"%s"' % check_conf_format()
 					else:


### PR DESCRIPTION
## Problem

- [*bsc#1204530*](https://bugzilla.suse.com/show_bug.cgi?id=1204530)
On SLE12SP5, after using yast2-cluster, both `crypto_hash` and `crypto_cipher` are `none` , and if the node is in the cloud environment, crmsh bootstrap will configure `udpu`, instead of `udp` when using yast2-cluster
- yast2-cluster will load `corosync.conf.example` when firstly running, the values from it might be invalid, should be dropped
- After dropped loadding `corosync.conf.example`, when configuring with mcast, the value of `mcastaddr` `mcastport` and `bindnetaddr` are missing
- Set focus on "Generate Auth Key File" when secauth is true
- Implement ValidateSecurity method
- Set focus on memberaddr add when using udpu


