### PR TITLE
Backport sp6

### DIFF
--- a/package/yast2-cluster.changes
+++ b/package/yast2-cluster.changes
@@ -2,6 +2,7 @@
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)
+- 4.6.2
 
 -------------------------------------------------------------------
 Thu Mar 23 07:55:52 UTC 2023 - Peter Varkoly <varkoly@suse.com>

--- a/package/yast2-cluster.spec
+++ b/package/yast2-cluster.spec
@@ -18,7 +18,7 @@
 %define _fwdefdir %{_prefix}/lib/firewalld/services
 
 Name:           yast2-cluster
-Version:        4.6.0
+Version:        4.6.2
 Release:        0
 Summary:        Configuration of cluster
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

SP6 branch is based on SP5 so evaluate changes in master and if version differs bump it to avoid version collision.


## Solution

Only fix in master is also in SP5 branch under different version, so lets just bump version.