### PR TITLE
[SLE-15-SP5] Update HA related ports (bsc#1219773)

### DIFF
--- a/package/cluster.firewalld.xml
+++ b/package/cluster.firewalld.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <service>
   <short>SUSE YaST Cluster</short>
-  <description>This allows you to open various ports related to SUSE YaST Cluster module. Ports are opened for pacemaker-remote, booth, mgmtd, hawk, dlm, csync2 and corosync-qnetd.</description>
-  <port protocol="tcp" port="2224"/>
-  <port protocol="tcp" port="3121"/>
-  <port protocol="tcp" port="5403"/>
-  <port protocol="udp" port="5404"/>
-  <port protocol="udp" port="5405"/>
-  <port protocol="tcp" port="5560"/>
-  <port protocol="tcp" port="7630"/>
-  <port protocol="tcp" port="9929"/>
+  <description>This allows you to open various ports related to SUSE YaST Cluster module. Ports are opened for pacemaker-remote, booth, hawk, dlm, csync2 and corosync-qnetd.</description>
+  <port protocol="tcp" port="3121"/> <!-- pacemaker-remote -->
+  <port protocol="tcp" port="5403"/> <!-- corosync-qnetd -->
+  <port protocol="udp" port="5404"/> <!-- corosync -->
+  <port protocol="udp" port="5405"/> <!-- corosync -->
+  <port protocol="tcp" port="7630"/> <!-- hawk -->
+  <port protocol="tcp" port="9929"/> <!-- booth -->
   <port protocol="udp" port="9929"/>
-  <port protocol="tcp" port="21064"/>
-  <port protocol="tcp" port="30865"/>
+  <port protocol="tcp" port="21064"/> <!-- dlm -->
+  <port protocol="stcp" port="21064"/>
+  <port protocol="tcp" port="30865"/> <!-- csync2 -->
 </service>
 

--- a/package/yast2-cluster.changes
+++ b/package/yast2-cluster.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jan 17 16:45:52 UTC 2025 - xin liang <xliang@suse.com>
+
+- Update HA related ports (bsc#1219773)
+- Version 4.5.3
+
+-------------------------------------------------------------------
 Thu Mar 23 07:55:52 UTC 2023 - Peter Varkoly <varkoly@suse.com>
 
 - bsc#1209602 bugs in yast2-cluster Write funcion

--- a/package/yast2-cluster.spec
+++ b/package/yast2-cluster.spec
@@ -18,7 +18,7 @@
 %define _fwdefdir %{_prefix}/lib/firewalld/services
 
 Name:           yast2-cluster
-Version:        4.5.2
+Version:        4.5.3
 Release:        0
 Summary:        Configuration of cluster
 License:        GPL-2.0-only

--- a/src/modules/Cluster.rb
+++ b/src/modules/Cluster.rb
@@ -694,11 +694,10 @@ module Yast
       udp_ports << @mcastport2 if @enable2 && @mcastport2 != ""
 
       # 30865 for csync2
-      # 5560 for mgmtd
       # 7630 for hawk or hawk2
       # 21064 for dlm
       # 5403 for corosync qdevice(default)
-      tcp_ports = ["30865", "5560", "21064", "7630"]
+      tcp_ports = ["30865", "21064", "7630"]
       tcp_ports << @qdevice_port if @corosync_qdevice
 
       begin


### PR DESCRIPTION
## Changed

- Add 21064/sctp for dlm
- Add comment for each port to explain which service it is for
- Remove 2224, which was for pcsd, RHEL CLI
- Remove 5560, which was for mgmtd, already deprecated
- Update version to 4.5.3


