### PR TITLE
[SLE-15-SP5] Fix: fix a typo for sctp in cluster.firewalld.xml (bsc#1236903)

### DIFF
--- a/package/cluster.firewalld.xml
+++ b/package/cluster.firewalld.xml
@@ -10,7 +10,7 @@
   <port protocol="tcp" port="9929"/> <!-- booth -->
   <port protocol="udp" port="9929"/>
   <port protocol="tcp" port="21064"/> <!-- dlm -->
-  <port protocol="stcp" port="21064"/>
+  <port protocol="sctp" port="21064"/>
   <port protocol="tcp" port="30865"/> <!-- csync2 -->
 </service>
 

--- a/package/yast2-cluster.changes
+++ b/package/yast2-cluster.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Feb  7 20:13:52 UTC 2025 - xin liang <xliang@suse.com>
+
+- Fix: fix a typo for sctp in cluster.firewalld.xml (bsc#1236903)
+- Version 4.5.4
+
+-------------------------------------------------------------------
 Fri Jan 17 16:45:52 UTC 2025 - xin liang <xliang@suse.com>
 
 - Update HA related ports (bsc#1219773)

--- a/package/yast2-cluster.spec
+++ b/package/yast2-cluster.spec
@@ -18,7 +18,7 @@
 %define _fwdefdir %{_prefix}/lib/firewalld/services
 
 Name:           yast2-cluster
-Version:        4.5.3
+Version:        4.5.4
 Release:        0
 Summary:        Configuration of cluster
 License:        GPL-2.0-only


### PR DESCRIPTION
## Changed

Fix a typo for sctp in cluster.firewalld.xml


